### PR TITLE
add article sort and order functionality and accept url search queries

### DIFF
--- a/src/components/AllArticles.jsx
+++ b/src/components/AllArticles.jsx
@@ -2,29 +2,44 @@ import { useState, useEffect } from "react";
 import { useParams } from "react-router-dom";
 import AllArticlesCards from "./AllArticlesCards";
 import AllArticlesButtons from "./AllArticlesButtons";
-import { fetchArticles, fetchArticlesByTopic } from "../utils/api";
+import {
+  fetchArticles,
+  fetchArticlesByTopic,
+  fetchArticlesByTopicAndSorted,
+} from "../utils/api";
+import AllArticlesSortBy from "./AllArticlesSortBy";
 
 const AllArticles = () => {
   const [articles, setArticles] = useState();
   const [isLoading, setIsLoading] = useState(true);
+  const [sortBy, setSortBy] = useState();
+  const [orderBy, setOrderBy] = useState("asc");
   const { category } = useParams();
 
   useEffect(() => {
     setIsLoading(true);
-    if (category === "all" || !category) {
+    if ((!sortBy && category === "all") || !category) {
+      console.log("condition 1");
       fetchArticles().then((articles) => {
         setArticles(articles);
         setIsLoading(false);
       });
-    } else {
-      fetchArticlesByTopic(category)
-        .then((articles) => {
+    } else if ((sortBy && category === "all") || !category) {
+      console.log("condition 2");
+      fetchArticlesByTopicAndSorted(category, sortBy, orderBy).then(
+        (articles) => {
           setArticles(articles);
           setIsLoading(false);
-        })
-        .catch((err) => {});
+        }
+      );
+    } else {
+      console.log("condition 3");
+      fetchArticlesByTopic(category).then((articles) => {
+        setArticles(articles);
+        setIsLoading(false);
+      });
     }
-  }, [category]);
+  }, [category, sortBy, orderBy]);
 
   if (isLoading) {
     return (
@@ -36,7 +51,10 @@ const AllArticles = () => {
   } else {
     return (
       <>
+        <button onClick={() => setSortBy("created_at")}>Sort By</button>
+        <button onClick={() => setOrderBy("desc")}>Order By</button>
         <AllArticlesButtons />
+        <AllArticlesSortBy />
         <AllArticlesCards articles={articles} />
       </>
     );

--- a/src/components/AllArticles.jsx
+++ b/src/components/AllArticles.jsx
@@ -3,11 +3,7 @@ import { useParams, useSearchParams } from "react-router-dom";
 import AllArticlesCards from "./AllArticlesCards";
 import AllArticlesButtons from "./AllArticlesButtons";
 import AllArticlesSortBy from "./AllArticlesSortBy";
-import {
-  fetchArticles,
-  fetchArticlesByTopic,
-  fetchArticlesWithParams,
-} from "../utils/api";
+import { fetchArticles } from "../utils/api";
 
 const AllArticles = () => {
   const [articles, setArticles] = useState();
@@ -18,36 +14,21 @@ const AllArticles = () => {
 
   useEffect(() => {
     setIsLoading(true);
-    if (category === "all" || !category) {
-      if (Object.keys(queries).length <= 1) {
-        fetchArticles().then((articles) => {
-          setArticles(articles);
-          setIsLoading(false);
-        });
-      } else {
-        const param1 = queries[0][1];
-        const param2 = queries[1][1];
+    if (Object.keys(queries).length >= 2) {
+      const query1 = queries[0][1];
+      const query2 = queries[1][1];
 
-        fetchArticlesWithParams(param1, param2).then((articles) => {
-          setArticles(articles);
-          setIsLoading(false);
-        });
-      }
+      fetchArticles(query1, query2, category).then((articles) => {
+        setArticles(articles);
+        setIsLoading(false);
+      });
     } else {
-      if (category && Object.keys(queries).length === 0) {
-        fetchArticlesByTopic(category).then((articles) => {
+      fetchArticles("", "", category ? category : queries[0][1]).then(
+        (articles) => {
           setArticles(articles);
           setIsLoading(false);
-        });
-      } else {
-        const param1 = queries[0][1];
-        const param2 = queries[1][1];
-
-        fetchArticlesWithParams(param1, param2, category).then((articles) => {
-          setArticles(articles);
-          setIsLoading(false);
-        });
-      }
+        }
+      );
     }
   }, [category, searchParams]);
 

--- a/src/components/AllArticlesSortBy.jsx
+++ b/src/components/AllArticlesSortBy.jsx
@@ -1,0 +1,5 @@
+const AllArticlesSortBy = () => {
+  return <h3>Sort</h3>;
+};
+
+export default AllArticlesSortBy;

--- a/src/components/AllArticlesSortBy.jsx
+++ b/src/components/AllArticlesSortBy.jsx
@@ -1,5 +1,72 @@
-const AllArticlesSortBy = () => {
-  return <h3>Sort</h3>;
+import { useState } from "react";
+import { Button } from "react-bootstrap";
+
+const AllArticlesSortBy = ({ setSearchParams }) => {
+  const [menuParams, setMenuParams] = useState({
+    sort_by: "",
+    order: "asc",
+  });
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setMenuParams({ ...menuParams, [name]: value });
+  };
+
+  const handleClick = () => {
+    const paramsString = `sort_by=${menuParams.sort_by}&order=${menuParams.order}`;
+    const searchParams = new URLSearchParams(paramsString);
+
+    if (menuParams.sort_by === "") {
+      alert("Both search parameters required");
+    } else {
+      setSearchParams(searchParams);
+    }
+  };
+
+  const style = {
+    fontSize: "20px",
+    width: "100vw",
+    textAlign: "center",
+    position: "relative",
+  };
+
+  return (
+    <div style={style}>
+      <label style={{ marginRight: "10px" }}>Sort by:</label>
+      <select
+        style={{ marginRight: "10px", width: "10%" }}
+        onChange={handleChange}
+        value={menuParams.sort_by}
+        id="sort_by"
+        name="sort_by"
+      >
+        <option value="">None</option>
+        <option value="created_at">Date</option>
+        <option value="comment_count">Comment count</option>
+        <option value="votes">Votes</option>
+      </select>
+      <select
+        style={{ marginRight: "10px", width: "10%" }}
+        onChange={handleChange}
+        value={menuParams.order}
+        id="order"
+        name="order"
+      >
+        <option value="asc">Ascending</option>
+        <option value="desc">Descending</option>
+      </select>
+      <Button
+        size="sm"
+        variant="dark"
+        style={{
+          padding: "0px 10px 0px 10px",
+        }}
+        onClick={handleClick}
+      >
+        Update
+      </Button>
+    </div>
+  );
 };
 
 export default AllArticlesSortBy;

--- a/src/components/SingleArticlePage.jsx
+++ b/src/components/SingleArticlePage.jsx
@@ -3,10 +3,6 @@ import SingleArticleVotes from "./SingleArticleVotes";
 import Avvvatars from "avvvatars-react";
 
 const SingleArticlePage = ({ data }) => {
-  console.log(data);
-
-
-const SingleArticlePage = ({ data }) => {
   let readableDate = data["created_at"].slice(0, 10);
 
   console.log(data);

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -16,6 +16,23 @@ export const fetchArticlesByTopic = (topic) => {
   });
 };
 
+export const fetchArticlesByTopicAndSorted = (sort, order, topic) => {
+  if (!topic) {
+    return newsApi
+      .get(`articles?sort_by=${sort}&order=${order}`)
+      .then((res) => {
+        return res.data.articles;
+      });
+  } else {
+    console.log("test");
+    return newsApi
+      .get(`articles?sort_by=${sort}&order=${order}&topic=${topic}`)
+      .then((res) => {
+        return res.data.articles;
+      });
+  }
+};
+
 export const fetchArticlesById = (article_id) => {
   return newsApi.get(`/articles/${article_id}`).then((res) => {
     return res.data.article;

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -4,37 +4,21 @@ const newsApi = axios.create({
   baseURL: "https://josh-geeson-backend-project.herokuapp.com/api",
 });
 
-export const fetchArticles = () => {
-  return newsApi.get(`/articles`).then((res) => {
-    return res.data.articles;
-  });
-};
+export const fetchArticles = (sort, order, topic) => {
+  const params = {
+    topic: topic,
+    sort_by: sort,
+    order: order,
+  };
 
-export const fetchArticlesByTopic = (topic) => {
-  return newsApi.get(`/articles`, { params: { topic: topic } }).then((res) => {
-    return res.data.articles;
-  });
-};
-
-export const fetchArticlesWithParams = (sort, order, topic) => {
-  if (!topic || topic === "all") {
-    return newsApi
-      .get(`articles`, {
-        params: { sort_by: sort, order: order },
-      })
-      .then((res) => {
-        return res.data.articles;
-      });
-  } else {
-    return newsApi
-      .get(`articles`, {
-        params: { sort_by: sort, order: order, topic: topic },
-      })
-      .then((res) => {
-        console.log(res.data.articles);
-        return res.data.articles;
-      });
+  for (const key of Object.keys(params)) {
+    if (params[key] === "" || params[key] === "all") {
+      delete params[key];
+    }
   }
+  return newsApi.get(`/articles`, { params }).then((res) => {
+    return res.data.articles;
+  });
 };
 
 export const fetchArticlesById = (article_id) => {

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -11,23 +11,27 @@ export const fetchArticles = () => {
 };
 
 export const fetchArticlesByTopic = (topic) => {
-  return newsApi.get(`/articles?topic=${topic}`).then((res) => {
+  return newsApi.get(`/articles`, { params: { topic: topic } }).then((res) => {
     return res.data.articles;
   });
 };
 
-export const fetchArticlesByTopicAndSorted = (sort, order, topic) => {
-  if (!topic) {
+export const fetchArticlesWithParams = (sort, order, topic) => {
+  if (!topic || topic === "all") {
     return newsApi
-      .get(`articles?sort_by=${sort}&order=${order}`)
+      .get(`articles`, {
+        params: { sort_by: sort, order: order },
+      })
       .then((res) => {
         return res.data.articles;
       });
   } else {
-    console.log("test");
     return newsApi
-      .get(`articles?sort_by=${sort}&order=${order}&topic=${topic}`)
+      .get(`articles`, {
+        params: { sort_by: sort, order: order, topic: topic },
+      })
       .then((res) => {
+        console.log(res.data.articles);
         return res.data.articles;
       });
   }


### PR DESCRIPTION
If only one query is included, will load up all articles, if two queries for sort_by and order, will work as intended. If sort_by is not included and user searches for order and topic - this will eventually be handled as error 